### PR TITLE
Rocelecor

### DIFF
--- a/Analyzers/include/SMPAnalyzerCore.h
+++ b/Analyzers/include/SMPAnalyzerCore.h
@@ -99,6 +99,7 @@ public:
   double GetBinContentUser(TH2* hist,double valx,double valy,int sys);
   void GetDYLHEParticles(const vector<LHE>& lhes,LHE& l0,LHE& l1);
   void GetDYGenParticles(const vector<Gen>& gens,Gen& parton0,Gen& parton1,Gen& l0,Gen& l1,bool dressed);
+  Gen SMPGetGenMatchedLepton(const Lepton& lep, const std::vector<Gen>& gens, int mode=0);
   std::vector<Electron> SMPGetElectrons(TString id, double ptmin, double fetamax);
   std::vector<Muon> SMPGetMuons(TString id,double ptmin,double fetamax);
   void FillCutflow(TString histname,TString label,double weight);

--- a/tmp/AFBAnalyzer.txt
+++ b/tmp/AFBAnalyzer.txt
@@ -1,4 +1,5 @@
 SKFlat.py -a AFBAnalyzer -i DYJets -n 40 -y 2016
+SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DYJets -n 40 -y 2016
 SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DoubleEG -p B_ver2 -n 10 -y 2016
 SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DoubleEG -p C -n 10 -y 2016
 SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DoubleEG -p D -n 10 -y 2016
@@ -35,6 +36,22 @@ SKFlat.py -a AFBAnalyzer -i DYJets_Pt-100To250 -n 10 -y 2017
 SKFlat.py -a AFBAnalyzer -i DYJets_Pt-250To400 -n 5 -y 2017
 SKFlat.py -a AFBAnalyzer -i DYJets_Pt-400To650 -n 5 -y 2017
 SKFlat.py -a AFBAnalyzer -i DYJets_Pt-650ToInf -n 5 -y 2017
+SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DYJets -n 40 -y 2017
+SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DYJets_M-100to200 -n 20 -y 2017
+SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DYJets_M-200to400 -n 10 -y 2017
+SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DYJets_M-400to500 -n 5 -y 2017
+SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DYJets_M-500to700 -n 5 -y 2017
+SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DYJets_M-700to800 -n 5 -y 2017
+SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DYJets_M-800to1000 -n 5 -y 2017
+SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DYJets_M-1000to1500 -n 5 -y 2017
+SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DYJets_M-1500to2000 -n 5 -y 2017
+SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DYJets_M-2000to3000 -n 5 -y 2017
+SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DYJets_M-3000toInf -n 5 -y 2017
+#SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DYJets_Pt-50To100 -n 20 -y 2017
+SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DYJets_Pt-100To250 -n 10 -y 2017
+SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DYJets_Pt-250To400 -n 5 -y 2017
+SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DYJets_Pt-400To650 -n 5 -y 2017
+SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DYJets_Pt-650ToInf -n 5 -y 2017
 SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DoubleEG -p B -n 10 -y 2017
 SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DoubleEG -p C -n 10 -y 2017
 SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DoubleEG -p D -n 10 -y 2017
@@ -67,6 +84,22 @@ SKFlat.py -a AFBAnalyzer -i DYJets_Pt-100To250 -n 10 -y 2018
 SKFlat.py -a AFBAnalyzer -i DYJets_Pt-250To400 -n 5 -y 2018
 SKFlat.py -a AFBAnalyzer -i DYJets_Pt-400To650 -n 5 -y 2018
 SKFlat.py -a AFBAnalyzer -i DYJets_Pt-650ToInf -n 5 -y 2018
+SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DYJets -n 40 -y 2018
+SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DYJets_M-100to200 -n 20 -y 2018
+SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DYJets_M-200to400 -n 10 -y 2018
+SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DYJets_M-400to500 -n 5 -y 2018
+SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DYJets_M-500to700 -n 5 -y 2018
+SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DYJets_M-700to800 -n 5 -y 2018
+SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DYJets_M-800to1000 -n 5 -y 2018
+SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DYJets_M-1000to1500 -n 5 -y 2018
+SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DYJets_M-1500to2000 -n 5 -y 2018
+SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DYJets_M-2000to3000 -n 5 -y 2018
+SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DYJets_M-3000toInf -n 5 -y 2018
+SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DYJets_Pt-50To100 -n 20 -y 2018
+SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DYJets_Pt-100To250 -n 10 -y 2018
+SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DYJets_Pt-250To400 -n 5 -y 2018
+SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DYJets_Pt-400To650 -n 5 -y 2018
+SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i DYJets_Pt-650ToInf -n 5 -y 2018
 SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i EGamma -p A -n 10 -y 2018
 SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i EGamma -p B -n 10 -y 2018
 SKFlat.py -a AFBAnalyzer --skim SkimTree_Dilepton -i EGamma -p C -n 10 -y 2018


### PR DESCRIPTION
* Use dressed gen pt for rocelecor
* Change default ee channel eta cut to 2.4 since rocelecor don't have the correction for |eta|>2.4
* Correct typo in gen level pt cut
* Add 'ALL ' user flag for run reco level even though it is not skimmed sample
* Use UncorrPt for electron efficiency scale factor