### PR TITLE
fix bug in Analyzers;return to single thread hadd

### DIFF
--- a/Analyzers/src/AFBAnalyzer.C
+++ b/Analyzers/src/AFBAnalyzer.C
@@ -339,12 +339,12 @@ void AFBAnalyzer::executeEventWithChannelName(TString channelname){
       if(HasFlag("REGION_cf")){
 	if(p.leps.at(0)->Charge()>0&&p.leps.at(1)->Charge()>0) prefix="pp_"+prefix;
 	else if(p.leps.at(0)->Charge()<0&&p.leps.at(1)->Charge()<0) prefix="mm_"+prefix;
-	else return;
+	else continue;
       }else{
 	if(p.leps.at(0)->Charge()*p.leps.at(1)->Charge()>0) prefix="ss_"+prefix;
       }
       if(channelname.Contains(TRegexp("em20[0-9][0-9]"))){
-	if(p.leps.at(0)->LeptonFlavour() == p.leps.at(1)->LeptonFlavour()) return;
+	if(p.leps.at(0)->LeptonFlavour() == p.leps.at(1)->LeptonFlavour()) continue;
       }
       if(p.weightbit&NominalWeight) FillCutflow(channelname+"/"+prefix+"cutflow"+suffix,"dilepton",eventweight);
       if(p.leps.at(0)->Pt()>p.lep0ptcut&&p.leps.at(1)->Pt()>p.lep1ptcut){

--- a/Analyzers/src/EfficiencyValidation.C
+++ b/Analyzers/src/EfficiencyValidation.C
@@ -152,7 +152,7 @@ void EfficiencyValidation::executeEventWithChannelName(TString channelname){
       TString prefix=tauprefix;
       if(p.leps.at(0)->Charge()*p.leps.at(1)->Charge()>0)
 	//prefix="ss_"+prefix;
-	return;
+	continue;
       FillCutflow(channelname+"/"+prefix+"cutflow"+suffix,"OS dilepton",eventweight);
       if(p.leps.at(0)->Pt()>p.lep0ptcut&&p.leps.at(1)->Pt()>p.lep1ptcut){
 	FillCutflow(channelname+"/"+prefix+"cutflow"+suffix,"LepPtCut",eventweight);
@@ -260,6 +260,7 @@ void EfficiencyValidation::FillHistsEfficiency(TString pre,TString suffix,const 
     
     //for leptons
     for(int i=0;i<(int)leps.size();i++){
+      if(i>1) break;
       double pt=leps.at(i)->Pt();
       double eta=leps.at(i)->Eta();
       TString charge=leps.at(i)->Charge()>0?"p":"m";

--- a/python/SKFlat.py
+++ b/python/SKFlat.py
@@ -857,7 +857,7 @@ try:
 
             else:
               if IsKISTI or IsTAMSA:
-                os.system('hadd -j 4 -f '+outputname+'.root output/*.root >> JobStatus.log')
+                os.system('hadd -f '+outputname+'.root output/*.root >> JobStatus.log')
                 os.system('rm output/*.root')
                 #os.system('condor_run -a request_cpus=10 "hadd -j 10 -f '+outputname+'.root output/*.root 2>&1 >> JobStatus.log"')
               else:

--- a/tmp/200525ToAleko.cc
+++ b/tmp/200525ToAleko.cc
@@ -1,0 +1,93 @@
+#include <iostream>
+#include "TString.h"
+#include "TFile.h"
+using namespace std;
+void Save(TString channelname){
+  bool delete_canvas=true;
+  EfficiencyPlotter aa;
+  aa.SetupPlots("fig/efficiency/plot.dat");
+  Verbosity=VERBOSITY::WARNING;
+  bool ismuon=channelname.BeginsWith("m");
+  TString id="MediumID_Q";
+  TString slepton="e";
+  if(ismuon){
+    id="MediumID_trkIsoLoose_Q";
+    slepton="#mu";
+  }
+  TString sdilepton=slepton+slepton;
+  
+  TString default_option;
+  default_option="sysname:efficiencySF ytitle:Events";
+  aa.SavePlot("default/mass_"+channelname,"histname:"+channelname+"/m80to100/dimass_"+id+" xtitle:'m("+sdilepton+") [GeV]' "+default_option,delete_canvas);
+  aa.SavePlot("default/rapidity_"+channelname,"histname:"+channelname+"/m80to100/dirap_"+id+" xtitle:'y("+sdilepton+")' rebin:2 "+default_option,delete_canvas);
+  aa.SavePlot("default/pt_"+channelname,"histname:"+channelname+"/m80to100/dipt_"+id+" xtitle:'p_{T}("+sdilepton+") [GeV]' rebin:2 xmax:100 "+default_option,delete_canvas);
+  aa.SavePlot("default/l0pt_"+channelname,"histname:"+channelname+"/m80to100/l0pt_"+id+" xtitle:'leading "+slepton+" p_{T} [GeV]' xmin:20 xmax:80 "+default_option,delete_canvas);
+  aa.SavePlot("default/l1pt_"+channelname,"histname:"+channelname+"/m80to100/l1pt_"+id+" xtitle:'sub-leading "+slepton+" p_{T} [GeV]' xmin:10 xmax:60 "+default_option,delete_canvas);
+  aa.SavePlot("default/leta_"+channelname,"histname:"+channelname+"/m80to100/leta_"+id+" xtitle:'#eta("+slepton+")' xmin:-2.4 xmax:2.4 rebin:2 "+default_option,delete_canvas);
+  if(!ismuon) aa.SavePlot("default/lsceta_"+channelname,"histname:"+channelname+"/m80to100/lsceta_"+id+" xtitle:'#eta_{SC}("+slepton+")' rebin:2 "+default_option,delete_canvas);
+  
+  default_option="sysname:efficiencySF norm ytitle:Nomalized";
+  aa.SavePlot("norm/mass_"+channelname,"histname:"+channelname+"/m80to100/dimass_"+id+" xtitle:'m("+sdilepton+") [GeV]' "+default_option,delete_canvas);
+  aa.SavePlot("norm/rapidity_"+channelname,"histname:"+channelname+"/m80to100/dirap_"+id+" xtitle:'y("+sdilepton+")' rebin:2 "+default_option,delete_canvas);
+  aa.SavePlot("norm/pt_"+channelname,"histname:"+channelname+"/m80to100/dipt_"+id+" xtitle:'p_{T}("+sdilepton+") [GeV]' rebin:2 xmax:100 "+default_option,delete_canvas);
+  aa.SavePlot("norm/l0pt_"+channelname,"histname:"+channelname+"/m80to100/l0pt_"+id+" xtitle:'leading "+slepton+" p_{T} [GeV]' xmin:20 xmax:80 "+default_option,delete_canvas);
+  aa.SavePlot("norm/l1pt_"+channelname,"histname:"+channelname+"/m80to100/l1pt_"+id+" xtitle:'sub-leading "+slepton+" p_{T} [GeV]' xmin:10 xmax:60 "+default_option,delete_canvas);
+  aa.SavePlot("norm/leta_"+channelname,"histname:"+channelname+"/m80to100/leta_"+id+" xtitle:'#eta("+slepton+")' xmin:-2.4 xmax:2.4 rebin:2 "+default_option,delete_canvas);
+  if(!ismuon) aa.SavePlot("norm/lsceta_"+channelname,"histname:"+channelname+"/m80to100/lsceta_"+id+" xtitle:'#eta_{SC}("+slepton+")' rebin:2 "+default_option,delete_canvas);
+  
+  aa.SetupEntries("data sim sim_noSF");
+
+  default_option="sysname:efficiencySF ytitle:Events base:1";
+  aa.SavePlot("nosf/mass_"+channelname,"histname:"+channelname+"/m80to100/dimass_"+id+" xtitle:'m("+sdilepton+") [GeV]' "+default_option,delete_canvas);
+  aa.SavePlot("nosf/rapidity_"+channelname,"histname:"+channelname+"/m80to100/dirap_"+id+" xtitle:'y("+sdilepton+")' rebin:2 "+default_option,delete_canvas);
+  aa.SavePlot("nosf/pt_"+channelname,"histname:"+channelname+"/m80to100/dipt_"+id+" xtitle:'p_{T}("+sdilepton+") [GeV]' rebin:2 xmax:100 "+default_option,delete_canvas);
+  aa.SavePlot("nosf/l0pt_"+channelname,"histname:"+channelname+"/m80to100/l0pt_"+id+" xtitle:'leading "+slepton+" p_{T} [GeV]' xmin:20 xmax:80 "+default_option,delete_canvas);
+  aa.SavePlot("nosf/l1pt_"+channelname,"histname:"+channelname+"/m80to100/l1pt_"+id+" xtitle:'sub-leading "+slepton+" p_{T} [GeV]' xmin:10 xmax:60 "+default_option,delete_canvas);
+  aa.SavePlot("nosf/leta_"+channelname,"histname:"+channelname+"/m80to100/leta_"+id+" xtitle:'#eta("+slepton+")' xmin:-2.4 xmax:2.4 rebin:2 BMleg "+default_option,delete_canvas);
+  if(!ismuon) aa.SavePlot("nosf/lsceta_"+channelname,"histname:"+channelname+"/m80to100/lsceta_"+id+" xtitle:'#eta_{SC}("+slepton+")' rebin:2 BMleg "+default_option,delete_canvas);
+  
+  default_option="sysname:efficiencySF norm ytitle:Nomalized base:1";
+  aa.SavePlot("nosf_norm/mass_"+channelname,"histname:"+channelname+"/m80to100/dimass_"+id+" xtitle:'m("+sdilepton+") [GeV]' "+default_option,delete_canvas);
+  aa.SavePlot("nosf_norm/rapidity_"+channelname,"histname:"+channelname+"/m80to100/dirap_"+id+" xtitle:'y("+sdilepton+")' rebin:2 "+default_option,delete_canvas);
+  aa.SavePlot("nosf_norm/pt_"+channelname,"histname:"+channelname+"/m80to100/dipt_"+id+" xtitle:'p_{T}("+sdilepton+") [GeV]' rebin:2 xmax:100 "+default_option,delete_canvas);
+  aa.SavePlot("nosf_norm/l0pt_"+channelname,"histname:"+channelname+"/m80to100/l0pt_"+id+" xtitle:'leading "+slepton+" p_{T} [GeV]' xmin:20 xmax:80 "+default_option,delete_canvas);
+  aa.SavePlot("nosf_norm/l1pt_"+channelname,"histname:"+channelname+"/m80to100/l1pt_"+id+" xtitle:'sub-leading "+slepton+" p_{T} [GeV]' xmin:10 xmax:60 "+default_option,delete_canvas);
+  aa.SavePlot("nosf_norm/leta_"+channelname,"histname:"+channelname+"/m80to100/leta_"+id+" xtitle:'#eta("+slepton+")' xmin:-2.4 xmax:2.4 rebin:2 BMleg "+default_option,delete_canvas);
+  if(!ismuon) aa.SavePlot("nosf_norm/lsceta_"+channelname,"histname:"+channelname+"/m80to100/lsceta_"+id+" xtitle:'#eta_{SC}("+slepton+")' rebin:2 BMleg "+default_option,delete_canvas);
+}
+void SaveAll(){
+  TString channelnames[]={"ee2016","ee2017","ee2018","mm2016","mm2017","mm2018","el2016","el2017","el2018","mu2016","mu2017","mu2018"};
+  for(auto channelname:channelnames) Save(channelname);
+}
+void make_muon_link(std::ostream& out=std::cout){
+  TString prefix="https://wjun.web.cern.ch/wjun/Muon/AFB_Efficiency/";
+  vector<pair<TString,TString>> pairs={
+    {"Medium trkIsoLoose","2016BF_IDISO"},
+    {"Single muon","2016BF_IsoMu24"},
+    {"Double muon Leg1 (Mu17)","2016BF_Mu17"},
+    {"Double muon Leg2 (Mu8)","2016BF_Mu8"},
+    {"Medium trkIsoLoose","2016GH_IDISO"},
+    {"Single muon","2016GH_IsoMu24"},
+    {"Double muon Leg1 (Mu17)","2016GH_Mu17"},
+    {"Double muon Leg2 (Mu8)","2016GH_Mu8"},
+    {"Medium trkIsoLoose","2017_IDISO"},
+    {"Single muon","2017_IsoMu27"},
+    {"Double muon Leg1 (Mu17)","2017_Mu17"},
+    {"Double muon Leg2 (Mu8)","2017_Mu8"},
+    {"Medium trkIsoLoose","2018_IDISO"},
+    {"Single muon","2018_IsoMu27"},
+    {"Double muon Leg1 (Mu17)","2018_Mu17"},
+    {"Double muon Leg2 (Mu8)","2018_Mu8"},
+  };
+  cout<<"<table>"<<endl;
+  for(auto [title,path]:pairs){
+    cout<<"<tr>"<<endl;
+    cout<<"<td>"+title+"</td>"<<endl;
+    cout<<"<td>+: <a href=\""+prefix+path+"_+/Plots\">plots</a> <a href=\""+prefix+path+"_+/result.root\">root</a> <br>-: <a href=\""+prefix+path+"_-/Plots\">plots</a> <a href=\""+prefix+path+"_-/result.root\">root</a> </td>"<<endl;
+    cout<<"</tr>"<<endl;
+  }
+  cout<<"</table>"<<endl;
+}
+   
+
+


### PR DESCRIPTION
* bug fix: `return` should be `continue` in the lepton loop
* return to single thread hadd
  * multi-thread hadd is much faster but I think it may be the cause of the file corruption (Segment violation in Plotter)
  * I implemented auto-recovery script in [Plotter](https://github.com/sansan9401/Plotter/commit/a1cb7c6924d540c1a4190d43c5d71a32f0a212f3#diff-20016b255d7de3e9d006f075ab7c2cbcR137-R150)). But, it may be not perfect. So, let's return to single-thread hadd.
